### PR TITLE
Upload to aws S3 instead of bundleservice

### DIFF
--- a/codalab/worker/bundle_service_client.py
+++ b/codalab/worker/bundle_service_client.py
@@ -163,6 +163,21 @@ class BundleServiceClient(RestClient):
                 progress_callback=progress_callback,
             )
 
+    @wrap_exception('Unable to update stderr stdout bundle contents in bundle service')
+    def update_bundle_contents_stderr_stdout(
+        self, worker_id, uuid, path, exclude_patterns, progress_callback
+    ):
+        with closing(
+            tar_gzip_directory_stderr_stdout(path, exclude_patterns=exclude_patterns)
+        ) as fileobj:
+            self._upload_with_chunked_encoding(
+                'PUT',
+                '/bundles/' + uuid + '/contents/blob/',
+                query_params={'filename': 'bundle.tar.gz', 'finalize_on_success': 0},
+                fileobj=fileobj,
+                progress_callback=progress_callback,
+            )
+
     @wrap_exception('Unable to get worker code')
     def get_code(self):
         return self._make_request(

--- a/codalab/worker/bundle_service_client.py
+++ b/codalab/worker/bundle_service_client.py
@@ -10,7 +10,7 @@ import urllib.parse
 import urllib.error
 
 from .rest_client import RestClient, RestClientException
-from .file_util import tar_gzip_directory
+from .file_util import tar_gzip_directory, tar_gzip_directory_stderr_stdout
 from codalab.common import ensure_str, URLOPEN_TIMEOUT_SECONDS
 
 

--- a/codalab/worker/worker.py
+++ b/codalab/worker/worker.py
@@ -133,7 +133,7 @@ class Worker:
             shared_file_system=self.shared_file_system,
         )
         self.s3_client = boto3.client('s3')
-        self.s3_bucket = "nlpbatch"
+        self.s3_bucket = "stanfordnlp"
 
     def init_docker_networks(self, docker_network_prefix, verbose=True):
         """

--- a/codalab/worker/worker.py
+++ b/codalab/worker/worker.py
@@ -22,6 +22,7 @@ from .bundle_service_client import BundleServiceException, BundleServiceClient
 from .dependency_manager import DependencyManager
 from .docker_image_manager import DockerImageManager
 from .download_util import BUNDLE_NO_LONGER_RUNNING_MESSAGE
+from .file_util import tar_gzip_directory
 from .state_committer import JsonStateCommitter
 from .bundle_state import BundleInfo, RunResources, BundleCheckinState
 from .worker_run_state import RunStateMachine, RunStage, RunState

--- a/codalab/worker/worker.py
+++ b/codalab/worker/worker.py
@@ -12,6 +12,7 @@ from typing import Optional, Set, Dict
 
 import psutil
 
+import boto3
 import docker
 from codalab.lib.telemetry_util import capture_exception, using_sentry
 import codalab.worker.docker_utils as docker_utils

--- a/codalab/worker/worker.py
+++ b/codalab/worker/worker.py
@@ -1,3 +1,4 @@
+from contextlib import closing
 import logging
 import os
 import shutil

--- a/codalab/worker/worker.py
+++ b/codalab/worker/worker.py
@@ -23,7 +23,7 @@ from .bundle_service_client import BundleServiceException, BundleServiceClient
 from .dependency_manager import DependencyManager
 from .docker_image_manager import DockerImageManager
 from .download_util import BUNDLE_NO_LONGER_RUNNING_MESSAGE
-from .file_util import tar_gzip_directory, tar_gzip_directory_stderr_stdout
+from .file_util import tar_gzip_directory
 from .state_committer import JsonStateCommitter
 from .bundle_state import BundleInfo, RunResources, BundleCheckinState
 from .worker_run_state import RunStateMachine, RunStage, RunState

--- a/codalab/worker/worker.py
+++ b/codalab/worker/worker.py
@@ -728,7 +728,7 @@ class Worker:
     def upload_bundle_contents(self, bundle_uuid, bundle_path, exclude_patterns, update_status):
         with closing(tar_gzip_directory(bundle_path, exclude_patterns=exclude_patterns)) as fileobj:
             self.s3_client.upload_fileobj(
-                fileobj, self.s3_bucket, f"codalab/{bundle_uuid}", callback=update_status
+                fileobj, self.s3_bucket, f"codalab/{bundle_uuid}", Callback=update_status
             )
         with closing(
             tar_gzip_directory_stderr_stdout(bundle_path, exclude_patterns=exclude_patterns)

--- a/codalab/worker/worker.py
+++ b/codalab/worker/worker.py
@@ -24,6 +24,7 @@ from .dependency_manager import DependencyManager
 from .docker_image_manager import DockerImageManager
 from .download_util import BUNDLE_NO_LONGER_RUNNING_MESSAGE
 from .file_util import tar_gzip_directory, tar_gzip_directory_stderr_stdout
+from .rest_client import _upload_with_chunked_encoding
 from .state_committer import JsonStateCommitter
 from .bundle_state import BundleInfo, RunResources, BundleCheckinState
 from .worker_run_state import RunStateMachine, RunStage, RunState

--- a/codalab/worker/worker.py
+++ b/codalab/worker/worker.py
@@ -725,10 +725,8 @@ class Worker:
     def upload_bundle_contents(self, bundle_uuid, bundle_path, exclude_patterns, update_status):
         with closing(tar_gzip_directory(bundle_path, exclude_patterns=exclude_patterns)) as fileobj:
             self.s3_client.upload_fileobj(
-                fileobj,
-                self.s3_bucket,
-                f"codalab/{bundle_uuid}",
-                callback=update_status)
+                fileobj, self.s3_bucket, f"codalab/{bundle_uuid}", callback=update_status
+            )
 
     def read_run_missing(self, socket_id):
         message = {

--- a/codalab/worker_manager/aws_batch_worker_manager.py
+++ b/codalab/worker_manager/aws_batch_worker_manager.py
@@ -89,7 +89,7 @@ class AWSBatchWorkerManager(WorkerManager):
         return [WorkerJob(job['status'] == 'RUNNING') for job in jobs]
 
     def start_worker_job(self):
-        image = 'nelson-liu/s3-cl-worker:latest'
+        image = 'nfliu/s3-cl-worker:latest'
         worker_id = uuid.uuid4().hex
         logger.debug('Starting worker %s with image %s', worker_id, image)
         work_dir_prefix = (

--- a/codalab/worker_manager/aws_batch_worker_manager.py
+++ b/codalab/worker_manager/aws_batch_worker_manager.py
@@ -89,7 +89,7 @@ class AWSBatchWorkerManager(WorkerManager):
         return [WorkerJob(job['status'] == 'RUNNING') for job in jobs]
 
     def start_worker_job(self):
-        image = 'codalab/worker:' + os.environ.get('CODALAB_VERSION', 'latest')
+        image = 'nelson-liu/s3-cl-worker:latest'
         worker_id = uuid.uuid4().hex
         logger.debug('Starting worker %s with image %s', worker_id, image)
         work_dir_prefix = (

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,5 @@ diffimg==0.2.3
 selenium==3.141.0
 requests==2.24.0
 sentry-sdk==0.18.0
+
+boto3==1.15.7


### PR DESCRIPTION
This is a hacky PR to make AWS Batch WorkerManagers upload to s3, instead of the bundle service (since the bundle service might be flaky).